### PR TITLE
Enabling the scheduler

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,5 +1,7 @@
 name: Call Collection Run
 on:
+  schedule:
+    - cron: 0 0 * * *
   workflow_dispatch: null
 jobs:
   call-workflow:


### PR DESCRIPTION
Enabling the scheduler for floor risk zone so it is runs every night.

Reference ticket: https://trello.com/c/keRruoB8/344-adding-flood-risk-zone-data-spike