### PR TITLE
Content disposition "attached" for flattened dataset files in S3 bucket

### DIFF
--- a/makerules/pipeline.mk
+++ b/makerules/pipeline.mk
@@ -144,7 +144,7 @@ clean::
 init::	$(CACHE_DIR)organisation.csv
 
 makerules::
-	curl -qfsL '$(SOURCE_URL)/makerules/main/pipeline.mk' > makerules/pipeline.mk
+	curl -qfsL '$(SOURCE_URL)/makerules/feature/flattened-dataset-content-disposition/pipeline.mk' > makerules/pipeline.mk
 
 save-transformed::
 	aws s3 sync $(TRANSFORMED_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(TRANSFORMED_DIR) --no-progress

--- a/makerules/pipeline.mk
+++ b/makerules/pipeline.mk
@@ -158,7 +158,7 @@ save-dataset::
 ifeq ($(HOISTED_COLLECTION_DATASET_BUCKET_NAME),digital-land-$(ENVIRONMENT)-collection-dataset-hoisted)
 	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/data/ --no-progress
 else
-	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/dataset/ --no-progress --content-disposition attached
+	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/dataset/ --no-progress --content-disposition attachment
 endif
 
 save-expectations::

--- a/makerules/pipeline.mk
+++ b/makerules/pipeline.mk
@@ -158,7 +158,7 @@ save-dataset::
 ifeq ($(HOISTED_COLLECTION_DATASET_BUCKET_NAME),digital-land-$(ENVIRONMENT)-collection-dataset-hoisted)
 	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/data/ --no-progress
 else
-	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/dataset/ --no-progress
+	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/dataset/ --no-progress --content-disposition attached
 endif
 
 save-expectations::

--- a/makerules/pipeline.mk
+++ b/makerules/pipeline.mk
@@ -144,7 +144,7 @@ clean::
 init::	$(CACHE_DIR)organisation.csv
 
 makerules::
-	curl -qfsL '$(SOURCE_URL)/makerules/feature/flattened-dataset-content-disposition/pipeline.mk' > makerules/pipeline.mk
+	curl -qfsL '$(SOURCE_URL)/makerules/main/pipeline.mk' > makerules/pipeline.mk
 
 save-transformed::
 	aws s3 sync $(TRANSFORMED_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(TRANSFORMED_DIR) --no-progress


### PR DESCRIPTION
Added content disposition option to s3 sync for the flattened dataset files to address the issue described in the following Trello ticket:

https://trello.com/c/kI3Jd0nH/3399-downloading-of-large-geojson-files-from-platform?filter=label:Infrastructure,label:DevOps

With the content disposition metadata set on an S3 object, requests receive a `Content-Disposition: attachment` response header. Browsers automatically handle such responses as a background file download, rather than loading contents in the browser viewport. 